### PR TITLE
Restore scanning: fix the artifact collector aborting on SIGPIPE

### DIFF
--- a/scripts/fetch-metadata-artifacts.sh
+++ b/scripts/fetch-metadata-artifacts.sh
@@ -63,7 +63,10 @@ for name in $NAMES; do
     exit 1
   fi
 
-  run_id="$(printf '%s\n' "$listing" | sort -rk1 | head -1 | awk '{print $2}')"
+  # awk rather than `head -1`: head closes the pipe after the first line, and
+  # with hundreds of artifacts still to write sort dies of SIGPIPE, which
+  # `pipefail` turns into an aborted run.  awk consumes the whole stream.
+  run_id="$(printf '%s\n' "$listing" | sort -rk1 | awk 'NR == 1 { print $2 }')"
 
   if [ -z "$run_id" ]; then
     echo "  ${name}: none published yet"

--- a/tests/unit/test_fetch_metadata_artifacts.py
+++ b/tests/unit/test_fetch_metadata_artifacts.py
@@ -1,0 +1,126 @@
+"""Tests for scripts/fetch-metadata-artifacts.sh.
+
+This script gates every scan workflow: it runs before the scan and aborts the
+job on failure, so a defect here stops all scanning rather than degrading it.
+It has already done so once -- ``sort -rk1 | head -1`` left ``sort`` writing
+into a pipe that ``head`` had closed, and under ``set -euo pipefail`` the
+resulting SIGPIPE aborted every collecting workflow.
+
+The stub below therefore emits a listing large enough to exceed the pipe
+buffer. That detail is the whole point: an earlier stub returned a single line,
+``sort`` fitted its output into the buffer before ``head`` exited, and the bug
+did not reproduce even though the script was broken in production.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "fetch-metadata-artifacts.sh"
+
+# Comfortably past the 64 KiB pipe buffer at ~32 bytes per line.
+LISTING_LINES = 6000
+
+pytestmark = pytest.mark.skipif(
+    not SCRIPT.is_file() or shutil.which("bash") is None,
+    reason="script or bash not available in this checkout",
+)
+
+
+def _stub_gh(tmp_path: Path, *, api_lines: int = LISTING_LINES,
+             api_fails: bool = False, download_fails: bool = False) -> Path:
+    """Write a fake `gh` onto PATH and return its directory."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir(parents=True, exist_ok=True)
+    gh = bindir / "gh"
+    gh.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [ "$1" = "api" ]; then\n'
+        f"  {'exit 1' if api_fails else ''}\n"
+        f"  for i in $(seq 1 {api_lines}); do\n"
+        "    printf '2026-01-%02dT00:00:00Z %d\\n' $((i % 28 + 1)) $((31700000000 + i))\n"
+        "  done\n"
+        "  exit 0\n"
+        "fi\n"
+        'if [ "$1" = "run" ]; then\n'
+        f"  {'exit 1' if download_fails else ''}\n"
+        '  mkdir -p "${@: -1}"; : > "${@: -1}/metadata.db"; exit 0\n'
+        "fi\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+    return bindir
+
+
+def _run(tmp_path: Path, bindir: Path) -> subprocess.CompletedProcess:
+    """Run the script with the stub on PATH."""
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}{os.pathsep}{env['PATH']}"
+    env["GITHUB_REPOSITORY"] = "owner/repo"
+    env["FETCH_ARTIFACT_ATTEMPTS"] = "1"
+    return subprocess.run(
+        ["bash", str(SCRIPT), str(tmp_path / "dest")],
+        capture_output=True, text=True, env=env,
+        cwd=SCRIPT.parents[1], timeout=120,
+    )
+
+
+def test_script_is_executable() -> None:
+    """The workflows invoke the path directly, not via `bash <path>`.
+
+    Losing the exec bit -- easy to do by rewriting the file through a
+    temporary copy -- fails every collecting job with "Permission denied".
+    The tests below run it through bash explicitly and so cannot see that,
+    which is exactly why this check is separate.
+    """
+    assert os.access(SCRIPT, os.X_OK), f"{SCRIPT} is not executable"
+
+
+class TestLargeListing:
+    """The regression that stopped every scan."""
+
+    def test_a_large_artifact_listing_does_not_abort_the_run(
+        self, tmp_path: Path
+    ) -> None:
+        result = _run(tmp_path, _stub_gh(tmp_path))
+
+        assert result.returncode == 0, (
+            f"exit {result.returncode}; stderr:\n{result.stderr}"
+        )
+        assert "write error" not in result.stderr
+
+    def test_the_newest_run_is_selected(self, tmp_path: Path) -> None:
+        """Selecting the wrong row would merge a stale database."""
+        result = _run(tmp_path, _stub_gh(tmp_path))
+
+        # Highest date in the stub is 2026-01-28; the largest run id on it wins.
+        assert "from run 31700005991" in result.stdout
+
+
+class TestFailureHandling:
+    """Failing loudly is the point; failing silently is what loses data."""
+
+    def test_unreadable_listing_aborts(self, tmp_path: Path) -> None:
+        """A 403 looks identical to 'nothing published' and must not pass."""
+        result = _run(tmp_path, _stub_gh(tmp_path, api_fails=True))
+
+        assert result.returncode == 1
+        assert "actions: read" in result.stderr
+
+    def test_failed_download_aborts(self, tmp_path: Path) -> None:
+        result = _run(tmp_path, _stub_gh(tmp_path, download_fails=True))
+
+        assert result.returncode == 1
+        assert "download failed" in result.stderr
+
+    def test_never_published_artifact_is_not_an_error(self, tmp_path: Path) -> None:
+        result = _run(tmp_path, _stub_gh(tmp_path, api_lines=0))
+
+        assert result.returncode == 0
+        assert "none published yet" in result.stdout


### PR DESCRIPTION
Every scan workflow has failed since #124 merged. This is the smallest change that restores them — two files, no behaviour change beyond the fix itself.

## What broke

`scripts/fetch-metadata-artifacts.sh` runs as the first real step of all twelve collecting workflows, and it aborts the job on failure. It has been aborting on every run.

```
sort: write error
##[error]Process completed with exit code 2.
```

`sort -rk1 | head -1` is the cause. `head` closes the pipe after one line; with a large artifact listing `sort` is still writing, takes SIGPIPE, and `set -euo pipefail` turns that into an aborted run. Replaced with `awk`, which consumes the whole stream.

The pipeline is not new — what changed in #124 is that it used to end in `|| true`. Rewriting the script to fail loudly on real errors removed the mask without removing the spurious failure underneath it.

A second, independent breakage was found while splitting this branch: the script had **lost its executable bit**. The workflows invoke the path directly, so that alone would have failed every collecting job with `Permission denied` as soon as the SIGPIPE fix landed. Restored here.

## No data was lost

Worth stating explicitly, since these workflows upload with `overwrite: true`. The `extract` step refused to build an artifact from a database that never got merged into:

```
Error: no working database at data/metadata.db; refusing to upload an empty artifact over existing data.
##[warning]No files were found with the provided path: data/upload/metadata.db. No artifacts will be uploaded.
```

So the uploads found no file and the stored artifacts were untouched. The guard held. Scanning stopped; history did not.

## Why the original testing missed it

The script *was* tested before merge, against a stub `gh`. The stub returned a **single line** — and with one line `sort` fits its output inside the 64 KiB pipe buffer before `head` exits, so no SIGPIPE occurs. The bug needs production's data *shape*, not just its interface.

The new tests emit 6000 lines specifically to exceed that buffer. They were confirmed to fail against the broken pipeline (3 failures) and pass against the fix. They also cover the paths the rewrite exists to protect:

| Test | Asserts |
|---|---|
| `test_a_large_artifact_listing_does_not_abort_the_run` | the regression itself — exit 0, no `write error` |
| `test_the_newest_run_is_selected` | selecting the wrong row would merge a stale database |
| `test_unreadable_listing_aborts` | a 403 looks identical to "nothing published" and must not pass |
| `test_failed_download_aborts` | a partial merge must not reach the `overwrite: true` upload |
| `test_never_published_artifact_is_not_an_error` | a genuinely absent artifact is fine |
| `test_script_is_executable` | separate, because the others run it through `bash` and cannot see the mode |

## Verification

- 993 tests passing; `ruff check src/ tests/ scripts/` clean.
- Both failure paths exercised against a stub `gh`: unreadable listing → exit 1, failed download → exit 1.
- Exec-bit guard confirmed to fail when the bit is stripped.

## Follow-up, deliberately not in this PR

`claude/retirement-observability` carries the edge-retirement lifecycle test and per-run health instrumentation. Kept separate so this diff stays reviewable while scans are down.

One thing worth addressing after: the upload steps are `if: always()`, so a failed collect still reaches the upload. It was harmless here only because `extract` refused first — the safety came from a single guard rather than from the workflow structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HAeD38MWYZ6RQkR7fym5hb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAeD38MWYZ6RQkR7fym5hb)_