### PR TITLE
Gate metadata upload on the merge actually succeeding

### DIFF
--- a/.github/workflows/issue-triggered-validation.yml
+++ b/.github/workflows/issue-triggered-validation.yml
@@ -59,6 +59,7 @@ jobs:
         run: scripts/fetch-metadata-artifacts.sh data/artifacts
 
       - name: Merge metadata artifacts
+        id: merge-metadata
         run: |
           python3 -m src.cli.metadata_artifact merge \
             --into data/metadata.db \
@@ -145,7 +146,7 @@ jobs:
       # database would republish a stale snapshot of every other scanner's
       # tables, undoing the isolation the split exists to provide.
       - name: Extract owned metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         continue-on-error: true
         run: |
           python3 -m src.cli.metadata_artifact extract \
@@ -154,7 +155,7 @@ jobs:
             --into data/upload/metadata.db
 
       - name: Upload validation-metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: validation-metadata

--- a/.github/workflows/reopen-validation-cycle.yml
+++ b/.github/workflows/reopen-validation-cycle.yml
@@ -56,6 +56,7 @@ jobs:
         run: scripts/fetch-metadata-artifacts.sh data/artifacts
 
       - name: Merge metadata artifacts
+        id: merge-metadata
         run: |
           python3 -m src.cli.metadata_artifact merge \
             --into data/metadata.db \
@@ -76,7 +77,7 @@ jobs:
       # database would republish a stale snapshot of every other scanner's
       # tables, undoing the isolation the split exists to provide.
       - name: Extract owned metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         continue-on-error: true
         run: |
           python3 -m src.cli.metadata_artifact extract \
@@ -85,7 +86,7 @@ jobs:
             --into data/upload/metadata.db
 
       - name: Upload validation-metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: validation-metadata

--- a/.github/workflows/scan-accessibility.yml
+++ b/.github/workflows/scan-accessibility.yml
@@ -74,6 +74,7 @@ jobs:
         run: scripts/fetch-metadata-artifacts.sh data/artifacts
 
       - name: Merge metadata artifacts
+        id: merge-metadata
         run: |
           python3 -m src.cli.metadata_artifact merge \
             --into data/metadata.db \
@@ -125,7 +126,7 @@ jobs:
       # database would republish a stale snapshot of every other scanner's
       # tables, undoing the isolation the split exists to provide.
       - name: Extract owned metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         continue-on-error: true
         run: |
           python3 -m src.cli.metadata_artifact extract \
@@ -134,7 +135,7 @@ jobs:
             --into data/upload/metadata.db
 
       - name: Upload accessibility-metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: accessibility-metadata

--- a/.github/workflows/scan-lighthouse.yml
+++ b/.github/workflows/scan-lighthouse.yml
@@ -89,6 +89,7 @@ jobs:
         run: scripts/fetch-metadata-artifacts.sh data/artifacts
 
       - name: Merge metadata artifacts
+        id: merge-metadata
         run: |
           python3 -m src.cli.metadata_artifact merge \
             --into data/metadata.db \
@@ -140,7 +141,7 @@ jobs:
       # database would republish a stale snapshot of every other scanner's
       # tables, undoing the isolation the split exists to provide.
       - name: Extract owned metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         continue-on-error: true
         run: |
           python3 -m src.cli.metadata_artifact extract \
@@ -149,7 +150,7 @@ jobs:
             --into data/upload/metadata.db
 
       - name: Upload lighthouse-metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: lighthouse-metadata

--- a/.github/workflows/scan-overlays.yml
+++ b/.github/workflows/scan-overlays.yml
@@ -57,6 +57,7 @@ jobs:
         run: scripts/fetch-metadata-artifacts.sh data/artifacts
 
       - name: Merge metadata artifacts
+        id: merge-metadata
         run: |
           python3 -m src.cli.metadata_artifact merge \
             --into data/metadata.db \
@@ -95,7 +96,7 @@ jobs:
       # database would republish a stale snapshot of every other scanner's
       # tables, undoing the isolation the split exists to provide.
       - name: Extract owned metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         continue-on-error: true
         run: |
           python3 -m src.cli.metadata_artifact extract \
@@ -104,7 +105,7 @@ jobs:
             --into data/upload/metadata.db
 
       - name: Upload overlay-metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: overlay-metadata

--- a/.github/workflows/scan-relationships.yml
+++ b/.github/workflows/scan-relationships.yml
@@ -63,6 +63,7 @@ jobs:
         run: scripts/fetch-metadata-artifacts.sh data/artifacts
 
       - name: Merge metadata artifacts
+        id: merge-metadata
         run: |
           python3 -m src.cli.metadata_artifact merge \
             --into data/metadata.db \
@@ -99,7 +100,7 @@ jobs:
       # database would republish a stale snapshot of every other scanner's
       # tables, undoing the isolation the split exists to provide.
       - name: Extract owned metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         continue-on-error: true
         run: |
           python3 -m src.cli.metadata_artifact extract \
@@ -108,7 +109,7 @@ jobs:
             --into data/upload/metadata.db
 
       - name: Upload relationship-scan-metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: relationship-scan-metadata

--- a/.github/workflows/scan-social-media.yml
+++ b/.github/workflows/scan-social-media.yml
@@ -67,6 +67,7 @@ jobs:
         run: scripts/fetch-metadata-artifacts.sh data/artifacts
 
       - name: Merge metadata artifacts
+        id: merge-metadata
         run: |
           python3 -m src.cli.metadata_artifact merge \
             --into data/metadata.db \
@@ -109,7 +110,7 @@ jobs:
       # database would republish a stale snapshot of every other scanner's
       # tables, undoing the isolation the split exists to provide.
       - name: Extract owned metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         continue-on-error: true
         run: |
           python3 -m src.cli.metadata_artifact extract \
@@ -118,7 +119,7 @@ jobs:
             --into data/upload/metadata.db
 
       - name: Upload social-media-metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: social-media-metadata

--- a/.github/workflows/scan-technology.yml
+++ b/.github/workflows/scan-technology.yml
@@ -71,6 +71,7 @@ jobs:
         run: scripts/fetch-metadata-artifacts.sh data/artifacts
 
       - name: Merge metadata artifacts
+        id: merge-metadata
         run: |
           python3 -m src.cli.metadata_artifact merge \
             --into data/metadata.db \
@@ -130,7 +131,7 @@ jobs:
       # database would republish a stale snapshot of every other scanner's
       # tables, undoing the isolation the split exists to provide.
       - name: Extract owned metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         continue-on-error: true
         run: |
           python3 -m src.cli.metadata_artifact extract \
@@ -139,7 +140,7 @@ jobs:
             --into data/upload/metadata.db
 
       - name: Upload technology-metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: technology-metadata

--- a/.github/workflows/scan-third-party-js.yml
+++ b/.github/workflows/scan-third-party-js.yml
@@ -60,6 +60,7 @@ jobs:
         run: scripts/fetch-metadata-artifacts.sh data/artifacts
 
       - name: Merge metadata artifacts
+        id: merge-metadata
         run: |
           python3 -m src.cli.metadata_artifact merge \
             --into data/metadata.db \
@@ -98,7 +99,7 @@ jobs:
       # database would republish a stale snapshot of every other scanner's
       # tables, undoing the isolation the split exists to provide.
       - name: Extract owned metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         continue-on-error: true
         run: |
           python3 -m src.cli.metadata_artifact extract \
@@ -107,7 +108,7 @@ jobs:
             --into data/upload/metadata.db
 
       - name: Upload third-party-js-metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: third-party-js-metadata

--- a/.github/workflows/validate-urls-batch.yml
+++ b/.github/workflows/validate-urls-batch.yml
@@ -86,6 +86,7 @@ jobs:
         run: scripts/fetch-metadata-artifacts.sh data/artifacts
 
       - name: Merge metadata artifacts
+        id: merge-metadata
         run: |
           python3 -m src.cli.metadata_artifact merge \
             --into data/metadata.db \
@@ -132,7 +133,7 @@ jobs:
       # database would republish a stale snapshot of every other scanner's
       # tables, undoing the isolation the split exists to provide.
       - name: Extract owned metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         continue-on-error: true
         run: |
           python3 -m src.cli.metadata_artifact extract \
@@ -141,7 +142,7 @@ jobs:
             --into data/upload/metadata.db
 
       - name: Upload validation-metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: validation-metadata

--- a/.github/workflows/validate-urls.yml
+++ b/.github/workflows/validate-urls.yml
@@ -65,6 +65,7 @@ jobs:
         run: scripts/fetch-metadata-artifacts.sh data/artifacts
 
       - name: Merge metadata artifacts
+        id: merge-metadata
         run: |
           python3 -m src.cli.metadata_artifact merge \
             --into data/metadata.db \
@@ -113,7 +114,7 @@ jobs:
       # database would republish a stale snapshot of every other scanner's
       # tables, undoing the isolation the split exists to provide.
       - name: Extract owned metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         continue-on-error: true
         run: |
           python3 -m src.cli.metadata_artifact extract \
@@ -122,7 +123,7 @@ jobs:
             --into data/upload/metadata.db
 
       - name: Upload validation-metadata
-        if: always()
+        if: always() && steps.merge-metadata.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: validation-metadata

--- a/tests/unit/test_metadata_merge.py
+++ b/tests/unit/test_metadata_merge.py
@@ -240,6 +240,23 @@ class TestWorkflowWiring:
 
         return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
 
+    def _metadata_upload_steps(self):
+        """Yield (path, job_name, step) for every step publishing an artifact.
+
+        Covers both the extract that builds the upload payload and the upload
+        itself, since either running on an unassembled database is the problem.
+        """
+        for path in self._workflows():
+            for job_name, job in (self._load(path).get("jobs") or {}).items():
+                for step in job.get("steps", []):
+                    name = str(step.get("name", ""))
+                    uploads_owned = (
+                        "upload-artifact" in str(step.get("uses", ""))
+                        and (step.get("with") or {}).get("name") in ARTIFACT_TABLES
+                    )
+                    if uploads_owned or name == "Extract owned metadata":
+                        yield path, job_name, step
+
     def _uploaders(self) -> dict[str, list[Path]]:
         """Map each known artifact to the workflows that upload it."""
         uploaders: dict[str, list[Path]] = {}
@@ -309,6 +326,46 @@ class TestWorkflowWiring:
                     f"{path.name} job {name!r} downloads metadata artifacts but "
                     f"has permissions {permissions}"
                 )
+
+    def test_metadata_upload_is_gated_on_a_successful_merge(self) -> None:
+        """`if: always()` on these steps is a data-loss path.
+
+        The upload replaces the stored artifact wholesale (``overwrite: true``),
+        so it must never publish a database that was not fully assembled.
+        ``merge_into`` creates the target schema before copying rows, so a merge
+        that fails part-way leaves a real-looking database on disk -- enough for
+        the extract to succeed and the upload to overwrite ninety days of
+        history with a partial snapshot.  Gating both steps on the merge's
+        outcome makes that structural rather than a happy accident of the
+        extract step refusing.
+        """
+        if not self._workflows():
+            pytest.skip("workflow directory not present in this checkout")
+
+        guard = "steps.merge-metadata.outcome == 'success'"
+        for path, job, step in self._metadata_upload_steps():
+            condition = str(step.get("if", ""))
+            assert guard in condition, (
+                f"{path.name} job {job!r} step {step.get('name')!r} has "
+                f"if: {condition!r}; it must be gated on the merge succeeding"
+            )
+
+    def test_the_merge_step_carries_the_id_the_guard_references(self) -> None:
+        """A guard pointing at a missing step id silently evaluates false."""
+        if not self._workflows():
+            pytest.skip("workflow directory not present in this checkout")
+
+        for path in self._workflows():
+            if "steps.merge-metadata.outcome" not in path.read_text(encoding="utf-8"):
+                continue
+            ids = {
+                step.get("id")
+                for job in (self._load(path).get("jobs") or {}).values()
+                for step in job.get("steps", [])
+            }
+            assert "merge-metadata" in ids, (
+                f"{path.name} guards on steps.merge-metadata but no step has that id"
+            )
 
     def test_every_uploader_merges_before_scanning(self) -> None:
         """Skip logic reads other scanners' results, so the merge must run."""


### PR DESCRIPTION
The last outstanding issue from the #125 collector outage. Eleven workflow files and one test; no change to scanning behaviour.

## The problem

The `Extract owned metadata` and `Upload <scanner>-metadata` steps ran `if: always()`, so they executed even when the database they publish had never been assembled. The upload replaces the stored artifact wholesale via `overwrite: true`, which makes this a data-loss path rather than a cosmetic one.

**A correction to how I first described this.** I originally said "a failed collect still reaches the upload". That is true but harmless: a failed collect leaves no database at all, so the extract refused with `no working database at data/metadata.db` and the upload found no file. That is exactly what happened throughout the outage, and no history was lost.

The case that guard does *not* cover is **a merge that fails part-way**. `merge_into` creates the target schema before copying any rows, so an interrupted merge leaves a real-looking database on disk — enough for the extract to succeed and the upload to replace ninety days of a scanner's history with a partial snapshot. Nothing in the run would report that as wrong.

So the safety we had came from a single guard inside a Python CLI, not from the shape of the workflow. This makes it structural.

## The change

```yaml
      - name: Merge metadata artifacts
        id: merge-metadata
        ...
      - name: Extract owned metadata
        if: always() && steps.merge-metadata.outcome == 'success'
      - name: Upload accessibility-metadata
        if: always() && steps.merge-metadata.outcome == 'success'
```

Applied to all eleven workflows that publish an owned artifact. `generate-scan-progress.yml` is unchanged — it merges but publishes nothing.

Scan failures still upload, deliberately: a partial scan on a correctly merged base is worth keeping. Only an unassembled base is refused.

## Two tests, both verified by re-breaking the thing they guard

| Test | Catches |
|---|---|
| `test_metadata_upload_is_gated_on_a_successful_merge` | any extract or owned-artifact upload reverting to bare `if: always()` |
| `test_the_merge_step_carries_the_id_the_guard_references` | the `id` being dropped while the guard stays |

The second matters more than it looks. A guard referencing a missing step id **silently evaluates false**, which would skip the upload forever rather than fail loudly — a worse failure than the one being fixed, and invisible without a test. Confirmed: reverting one upload to `if: always()` fails the first test, removing the `id` fails the second.

## Verification

- 995 tests passing; `ruff check src/ tests/ scripts/` clean.
- All twelve workflow YAMLs parse.
- `main` merged in first — the branch was one data commit behind and the diff would otherwise have reverted it. The diff is now eleven workflows plus one test, nothing under `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HAeD38MWYZ6RQkR7fym5hb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAeD38MWYZ6RQkR7fym5hb)_